### PR TITLE
Silenced initialization warning with -Wmissing-field-initializers

### DIFF
--- a/http.cpp
+++ b/http.cpp
@@ -336,7 +336,7 @@ void HttpServer::startListening(uint16_t port) {
         throw std::runtime_error("Could not set SO_REUSEADDR option");
     }
 
-    struct sockaddr_in remote = {0};
+    struct sockaddr_in remote = {};
 
     remote.sin_family = AF_INET;
     remote.sin_addr.s_addr = htonl(INADDR_ANY);


### PR DESCRIPTION
g++ -Wmissing-field-initializers -c http.cpp
http.cpp: In member function ‘void HttpServer::startListening(uint16_t)’: http.cpp:339:35: warning: missing initializer for member ‘sockaddr_in::sin_port’ [-Wmissing-field-initializers]
  339 |     struct sockaddr_in remote = {0};
      |                                   ^
http.cpp:339:35: warning: missing initializer for member ‘sockaddr_in::sin_addr’ [-Wmissing-field-initializers]
http.cpp:339:35: warning: missing initializer for member ‘sockaddr_in::sin_zero’ [-Wmissing-field-initializers]

The code was doing the right thing. But it actually relied on the default 0 values of the other fields. Instead, let us simply rely on the zero initialization for all fields.

See https://en.cppreference.com/w/cpp/language/zero_initialization